### PR TITLE
Update resolveLibConfig.js issue#2646

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveLibConfig.js
@@ -46,6 +46,7 @@ module.exports = (api, { entry, name }, options) => {
     // externalize Vue in case user imports it
     config
       .externals({
+        ...config.get('externals'),
         vue: {
           commonjs: 'vue',
           commonjs2: 'vue',


### PR DESCRIPTION
issue#2646
bug fix: vue-cli-service build --target lib ignores externals in vue.config.js